### PR TITLE
ignore external-secrets crds status - different paths

### DIFF
--- a/envs/homelab/apps/crds.yaml
+++ b/envs/homelab/apps/crds.yaml
@@ -58,3 +58,54 @@ spec:
       name: orders.acme.cert-manager.io
       jsonPointers:
         - /status
+  # external-secrets crds
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: acraccesstokens.generators.external-secrets.io
+      jsonPointers:
+        - /status
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: clusterexternalsecrets.external-secrets.io
+      jsonPointers:
+        - /status
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: clustersecretstores.external-secrets.io
+      jsonPointers:
+        - /status
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: ecrauthorizationtokens.generators.external-secrets.io 
+      jsonPointers:
+        - /status
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: fakes.generators.external-secrets.io
+      jsonPointers:
+        - /status
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: gcraccesstokens.generators.external-secrets.io
+      jsonPointers:
+        - /status
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: passwords.generators.external-secrets.io
+      jsonPointers:
+        - /status
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: pushsecrets.external-secrets.io
+      jsonPointers:
+        - /status
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: secretstores.external-secrets.io
+      jsonPointers:
+        - /status
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: vaultdynamicsecrets.generators.external-secrets.io
+      jsonPointers:
+        - /status

--- a/envs/homelab/apps/crds.yaml
+++ b/envs/homelab/apps/crds.yaml
@@ -59,53 +59,29 @@ spec:
       jsonPointers:
         - /status
   # external-secrets crds
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: acraccesstokens.generators.external-secrets.io
-      jsonPointers:
-        - /status
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: clusterexternalsecrets.external-secrets.io
-      jsonPointers:
-        - /status
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: clustersecretstores.external-secrets.io
-      jsonPointers:
-        - /status
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: ecrauthorizationtokens.generators.external-secrets.io 
-      jsonPointers:
-        - /status
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: fakes.generators.external-secrets.io
-      jsonPointers:
-        - /status
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: gcraccesstokens.generators.external-secrets.io
-      jsonPointers:
-        - /status
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: passwords.generators.external-secrets.io
-      jsonPointers:
-        - /status
-    - group: apiextensions.k8s.io
-      kind: CustomResourceDefinition
-      name: pushsecrets.external-secrets.io
-      jsonPointers:
-        - /status
+  # https://github.com/external-secrets/external-secrets/issues/1026
     - group: apiextensions.k8s.io
       kind: CustomResourceDefinition
       name: secretstores.external-secrets.io
-      jsonPointers:
-        - /status
+      jqPathExpressions:
+        - .spec.conversion.webhook.clientConfig
     - group: apiextensions.k8s.io
       kind: CustomResourceDefinition
-      name: vaultdynamicsecrets.generators.external-secrets.io
-      jsonPointers:
-        - /status
+      name: externalsecrets.external-secrets.io
+      jqPathExpressions:
+        - .spec.conversion.webhook.clientConfig
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      name: clustersecretstores.external-secrets.io
+      jqPathExpressions:
+        - .spec.conversion.webhook.clientConfig
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: secretstore-validate
+      jqPathExpressions:
+        - .webhooks[].clientConfig
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: externalsecret-validate
+      jqPathExpressions:
+        - .webhooks[].clientConfig


### PR DESCRIPTION
First set of ignore did not work. Looks like webhook related paths need to be ignored on these. 
