### PR TITLE
github actions-runner-controller runner image tag

### DIFF
--- a/envs/homelab/workloads/arc/runners.yaml
+++ b/envs/homelab/workloads/arc/runners.yaml
@@ -8,7 +8,7 @@ spec:
   scaleTargetRef:
     kind: RunnerDeployment
     name: ssm-sync
-  minReplicas: 0
+  minReplicas: 1
   maxReplicas: 2
   metrics:
   - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
@@ -22,6 +22,9 @@ metadata:
 spec:
   template:
     spec:
+      containers:
+        - name: runner
+          image: summerwind/actions-runner:ubuntu-20.04
       repository: larntz/ssm-sync
       labels:
         - homelab


### PR DESCRIPTION
The runner pods were using `latest`. Updated runner spec to specify image tag as `summerwind/actions-runner:ubuntu-20.04`.
